### PR TITLE
Fix/type hint functions return

### DIFF
--- a/src/V2/Records/ModuleHelper.php
+++ b/src/V2/Records/ModuleHelper.php
@@ -327,7 +327,7 @@ class ModuleHelper
      * @param array|null $triggers (optional) The triggers to enable
      * @return array|null
      */
-    public function insert($record, array $triggers = null)
+    public function insert($record, array $triggers = null): ?array
     {
         $response = $this->newInsertQuery([$record], $triggers)->get();
 
@@ -343,7 +343,7 @@ class ModuleHelper
      * @param array|null $triggers (optional) The triggers to enable
      * @return array[]
      */
-    public function insertMany($records, array $triggers = null)
+    public function insertMany($records, array $triggers = null): array
     {
         return $this->newInsertQuery($records, $triggers)->get();
     }
@@ -356,7 +356,7 @@ class ModuleHelper
      * @param array|null $triggers (optional) The triggers to enable
      * @return array|null
      */
-    public function update(string $id, $data, array $triggers = null)
+    public function update(string $id, $data, array $triggers = null): ?array
     {
         $response = $this->newUpdateQuery($id, $data, $triggers)->get();
 
@@ -372,7 +372,7 @@ class ModuleHelper
      * @param array|null $triggers (optional) The triggers to enable
      * @return array[]
      */
-    public function updateMany($records, array $triggers = null)
+    public function updateMany($records, array $triggers = null): array
     {
         return $this->newUpdateManyQuery($records, $triggers)->get();
     }
@@ -385,7 +385,7 @@ class ModuleHelper
      * @param array|null $triggers (optional) The triggers to enable
      * @return array|null
      */
-    public function upsert($record, array $duplicateCheckFields = null, array $triggers = null)
+    public function upsert($record, array $duplicateCheckFields = null, array $triggers = null): ?array
     {
         $response = $this->newUpsertQuery([$record], $duplicateCheckFields, $triggers)->get();
 
@@ -402,7 +402,7 @@ class ModuleHelper
      * @param array|null $triggers (optional) The triggers to enable
      * @return array[]
      */
-    public function upsertMany($records, array $duplicateCheckFields = null, array $triggers = null)
+    public function upsertMany($records, array $duplicateCheckFields = null, array $triggers = null): array
     {
         return $this->newUpsertQuery($records, $duplicateCheckFields, $triggers)->get();
     }
@@ -413,7 +413,7 @@ class ModuleHelper
      * @param string $id The ID of the record to delete
      * @return array|null
      */
-    public function delete(string $id)
+    public function delete(string $id): ?array
     {
         $response = $this->newDeleteQuery($id)->get();
 
@@ -428,7 +428,7 @@ class ModuleHelper
      * @param string[] $ids The IDs of the records to delete
      * @return array[]
      */
-    public function deleteMany(array $ids)
+    public function deleteMany(array $ids): array
     {
         return $this->newDeleteManyQuery($ids)->get();
     }

--- a/src/V2/Records/ModuleHelper.php
+++ b/src/V2/Records/ModuleHelper.php
@@ -313,9 +313,9 @@ class ModuleHelper
      * Retrieve a specific record by ID.
      *
      * @param string $id The record ID
-     * @return Record
+     * @return Record|null
      */
-    public function find(string $id): Record
+    public function find(string $id): ?Record
     {
         return $this->newGetByIdQuery($id)->get();
     }


### PR DESCRIPTION
Hello @tristanjahier!

How are you? I hope well! :smiley: 

@juanjo698 and I are using your package for a private project that maybe you know :wink:
The point is it was working well until we'are updated to [last commit](https://github.com/tristanjahier/zoho-crm-php/commit/60fba46b8130a2b44c4cd4a97c94d08616cac577). However, when we want to get a record from a module with the `find` function and if that record doesn't exist, the package returns the following error:

```batch
Return value of Zoho\Crm\V2\Records\ModuleHelper::find() must be an instance of Zoho\Crm\V2\Records\Record, null returned {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Return value of Zoho\\Crm\\V2\\Records\\ModuleHelper::find() must be an instance of Zoho\\Crm\\V2\\Records\\Record, null returned at /var/www/html/vendor/tristanjahier/zoho-crm-php/src/V2/Records/ModuleHelper.php:320)
```

We were researching a found that last version that we had on this function was: [https://github.com/tristanjahier/zoho-crm-php/blob/9f532dc2b4556837de02ab632dedb26b276eec5a/src/V2/Records/Module.php#L126](here) that not use type hint on function returns. 

We have changed it on local and works now.

Could you check it when you can, please?

PD: We have taken the opportunity for adding the return type hint to some functions.

Thanks!
 
 